### PR TITLE
Added fix to solve app bug when secondary monitor plugged-in

### DIFF
--- a/src/main.pas
+++ b/src/main.pas
@@ -639,7 +639,7 @@ begin
   SetTitle( Format(L_GET('app.title')+' © Tema567', [L_GET('app.name'), L_GET('app.ver')]) );
   Self.BorderStyle := bsDialog;
   Self.BorderIcons := [];
-  Self.Position := poDesktopCenter;
+  Self.Position := poScreenCenter;
   Self.DefaultMonitor := dmPrimary;
   { Get DPI value }
   dpi := Self.PixelsPerInch / 96;


### PR DESCRIPTION
Fix found by @**pvtstandon** in 2022, reported on Discord. The Key Man would be "hidden" in the 0px space between the two monitors; the workaround was to unplug the secondary monitor and start BF2KeyMan.exe again. This modified line fixes the problem of the app's start position.
![image 1](https://github.com/art567/bf2keyman/assets/25310397/81a50a7f-b5a0-4465-8f30-b1b11915f2c0)

_p.s. secretly looking to finally get the "Pull Shark" badge_ 😋